### PR TITLE
Add Treat Scan as 2 Pages option (WIA only)

### DIFF
--- a/NAPS2.Core/Scan/ScanProfile.cs
+++ b/NAPS2.Core/Scan/ScanProfile.cs
@@ -34,7 +34,7 @@ namespace NAPS2.Scan
 
         public ScanProfile Clone()
         {
-            var profile = (ScanProfile) MemberwiseClone();
+            var profile = (ScanProfile)MemberwiseClone();
             if (profile.AutoSaveSettings != null)
             {
                 profile.AutoSaveSettings = AutoSaveSettings.Clone();
@@ -123,6 +123,8 @@ namespace NAPS2.Scan
         public bool FlipDuplexedPages { get; set; }
 
         public KeyValueScanOptions KeyValueOptions { get; set; }
+
+        public bool TreatScanAsTwoPages { get; set; }
     }
 
     [Serializable]
@@ -146,7 +148,7 @@ namespace NAPS2.Scan
             Separator = SaveSeparator.FilePerPage;
         }
 
-        internal AutoSaveSettings Clone() => (AutoSaveSettings) MemberwiseClone();
+        internal AutoSaveSettings Clone() => (AutoSaveSettings)MemberwiseClone();
 
         public string FilePath { get; set; }
 

--- a/NAPS2.Core/WinForms/FAdvancedScanSettings.Designer.cs
+++ b/NAPS2.Core/WinForms/FAdvancedScanSettings.Designer.cs
@@ -42,6 +42,8 @@ namespace NAPS2.WinForms
             this.tbImageQuality = new System.Windows.Forms.TrackBar();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.cmbWiaVersion = new System.Windows.Forms.ComboBox();
+            this.label4 = new System.Windows.Forms.Label();
             this.cbForcePageSizeCrop = new System.Windows.Forms.CheckBox();
             this.cbFlipDuplex = new System.Windows.Forms.CheckBox();
             this.cbWiaOffsetWidth = new System.Windows.Forms.CheckBox();
@@ -60,8 +62,7 @@ namespace NAPS2.WinForms
             this.btnRestoreDefaults = new System.Windows.Forms.Button();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.cbAutoDeskew = new System.Windows.Forms.CheckBox();
-            this.cmbWiaVersion = new System.Windows.Forms.ComboBox();
-            this.label4 = new System.Windows.Forms.Label();
+            this.cbTreatScanAsTwoPages = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.tbImageQuality)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -129,6 +130,18 @@ namespace NAPS2.WinForms
             resources.ApplyResources(this.groupBox2, "groupBox2");
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
+            // 
+            // cmbWiaVersion
+            // 
+            this.cmbWiaVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbWiaVersion.FormattingEnabled = true;
+            resources.ApplyResources(this.cmbWiaVersion, "cmbWiaVersion");
+            this.cmbWiaVersion.Name = "cmbWiaVersion";
+            // 
+            // label4
+            // 
+            resources.ApplyResources(this.label4, "label4");
+            this.label4.Name = "label4";
             // 
             // cbForcePageSizeCrop
             // 
@@ -239,6 +252,7 @@ namespace NAPS2.WinForms
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.cbTreatScanAsTwoPages);
             this.groupBox4.Controls.Add(this.cbAutoDeskew);
             resources.ApplyResources(this.groupBox4, "groupBox4");
             this.groupBox4.Name = "groupBox4";
@@ -250,17 +264,11 @@ namespace NAPS2.WinForms
             this.cbAutoDeskew.Name = "cbAutoDeskew";
             this.cbAutoDeskew.UseVisualStyleBackColor = true;
             // 
-            // cmbWiaVersion
+            // cbTreatScanAsTwoPages
             // 
-            this.cmbWiaVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbWiaVersion.FormattingEnabled = true;
-            resources.ApplyResources(this.cmbWiaVersion, "cmbWiaVersion");
-            this.cmbWiaVersion.Name = "cmbWiaVersion";
-            // 
-            // label4
-            // 
-            resources.ApplyResources(this.label4, "label4");
-            this.label4.Name = "label4";
+            resources.ApplyResources(this.cbTreatScanAsTwoPages, "cbTreatScanAsTwoPages");
+            this.cbTreatScanAsTwoPages.Name = "cbTreatScanAsTwoPages";
+            this.cbTreatScanAsTwoPages.UseVisualStyleBackColor = true;
             // 
             // FAdvancedScanSettings
             // 
@@ -323,5 +331,6 @@ namespace NAPS2.WinForms
         private System.Windows.Forms.CheckBox cbAutoDeskew;
         private System.Windows.Forms.ComboBox cmbWiaVersion;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.CheckBox cbTreatScanAsTwoPages;
     }
 }

--- a/NAPS2.Core/WinForms/FAdvancedScanSettings.cs
+++ b/NAPS2.Core/WinForms/FAdvancedScanSettings.cs
@@ -46,6 +46,7 @@ namespace NAPS2.WinForms
             txtImageQuality.Text = scanProfile.Quality.ToString("G");
             cbBrightnessContrastAfterScan.Checked = scanProfile.BrightnessContrastAfterScan;
             cbAutoDeskew.Checked = scanProfile.AutoDeskew;
+            cbTreatScanAsTwoPages.Checked = scanProfile.TreatScanAsTwoPages;
             cbWiaOffsetWidth.Checked = scanProfile.WiaOffsetWidth;
             cmbWiaVersion.SelectedIndex = (int)scanProfile.WiaVersion;
             cbForcePageSize.Checked = scanProfile.ForcePageSize;
@@ -80,6 +81,7 @@ namespace NAPS2.WinForms
             ScanProfile.MaxQuality = cbHighQuality.Checked;
             ScanProfile.BrightnessContrastAfterScan = cbBrightnessContrastAfterScan.Checked;
             ScanProfile.AutoDeskew = cbAutoDeskew.Checked;
+            ScanProfile.TreatScanAsTwoPages = cbTreatScanAsTwoPages.Checked;
             ScanProfile.WiaOffsetWidth = cbWiaOffsetWidth.Checked;
             if (cmbWiaVersion.SelectedIndex != -1)
             {

--- a/NAPS2.Core/WinForms/FAdvancedScanSettings.resx
+++ b/NAPS2.Core/WinForms/FAdvancedScanSettings.resx
@@ -792,6 +792,36 @@
   <data name="&gt;&gt;btnRestoreDefaults.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="cbTreatScanAsTwoPages.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbTreatScanAsTwoPages.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbTreatScanAsTwoPages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>190, 18</value>
+  </data>
+  <data name="cbTreatScanAsTwoPages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 17</value>
+  </data>
+  <data name="cbTreatScanAsTwoPages.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="cbTreatScanAsTwoPages.Text" xml:space="preserve">
+    <value>Treat scan as two pages</value>
+  </data>
+  <data name="&gt;&gt;cbTreatScanAsTwoPages.Name" xml:space="preserve">
+    <value>cbTreatScanAsTwoPages</value>
+  </data>
+  <data name="&gt;&gt;cbTreatScanAsTwoPages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbTreatScanAsTwoPages.Parent" xml:space="preserve">
+    <value>groupBox4</value>
+  </data>
+  <data name="&gt;&gt;cbTreatScanAsTwoPages.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="cbAutoDeskew.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -820,7 +850,7 @@
     <value>groupBox4</value>
   </data>
   <data name="&gt;&gt;cbAutoDeskew.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="groupBox4.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 248</value>
@@ -892,12 +922,12 @@
     <value>ilProfileIcons</value>
   </data>
   <data name="&gt;&gt;ilProfileIcons.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ILProfileIcons, NAPS2.Core, Version=6.0.3.32183, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ILProfileIcons, NAPS2.Core, Version=6.1.2.35748, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>FAdvancedScanSettings</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=6.0.3.32183, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=6.1.2.35748, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/NAPS2.Core/WinForms/FEditProfile.cs
+++ b/NAPS2.Core/WinForms/FEditProfile.cs
@@ -308,6 +308,7 @@ namespace NAPS2.WinForms
                 Quality = ScanProfile.Quality,
                 BrightnessContrastAfterScan = ScanProfile.BrightnessContrastAfterScan,
                 AutoDeskew = ScanProfile.AutoDeskew,
+                TreatScanAsTwoPages = ScanProfile.TreatScanAsTwoPages,
                 WiaOffsetWidth = ScanProfile.WiaOffsetWidth,
                 WiaRetryOnFailure = ScanProfile.WiaRetryOnFailure,
                 WiaDelayBetweenScans = ScanProfile.WiaDelayBetweenScans,


### PR DESCRIPTION
Allows a double-page scan to be automatically split into two pages (with rotation) for when scanning magazines with staples removed.