### PR TITLE
Correct pixel ordering to BGR not RGB for luma calcs

### DIFF
--- a/NAPS2.Core/Scan/Images/Transforms/UnsafeImageOps.cs
+++ b/NAPS2.Core/Scan/Images/Transforms/UnsafeImageOps.cs
@@ -32,21 +32,21 @@ namespace NAPS2.Scan.Images.Transforms
                     for (int x = 0; x < w; x++)
                     {
                         byte* pixel = row + x * bytesPerPixel;
-                        byte r = *pixel;
+                        byte b = *pixel;
                         byte g = *(pixel + 1);
-                        byte b = *(pixel + 2);
+                        byte r = *(pixel + 2);
 
-                        int r2 = (int)(r + brightnessAdjusted);
-                        int g2 = (int)(g + brightnessAdjusted);
                         int b2 = (int)(b + brightnessAdjusted);
+                        int g2 = (int)(g + brightnessAdjusted);
+                        int r2 = (int)(r + brightnessAdjusted);
 
-                        r = (byte)(r2 < 0 ? 0 : r2 > 255 ? 255 : r2);
-                        g = (byte)(g2 < 0 ? 0 : g2 > 255 ? 255 : g2);
                         b = (byte)(b2 < 0 ? 0 : b2 > 255 ? 255 : b2);
+                        g = (byte)(g2 < 0 ? 0 : g2 > 255 ? 255 : g2);
+                        r = (byte)(r2 < 0 ? 0 : r2 > 255 ? 255 : r2);
 
-                        *pixel = r;
+                        *pixel = b;
                         *(pixel + 1) = g;
-                        *(pixel + 2) = b;
+                        *(pixel + 2) = r;
                     }
                 }
             });
@@ -74,21 +74,21 @@ namespace NAPS2.Scan.Images.Transforms
                     for (int x = 0; x < w; x++)
                     {
                         byte* pixel = row + x * bytesPerPixel;
-                        byte r = *pixel;
+                        byte b = *pixel;
                         byte g = *(pixel + 1);
-                        byte b = *(pixel + 2);
+                        byte r = *(pixel + 2);
 
-                        int r2 = (int)(r * contrastAdjusted + offset);
-                        int g2 = (int)(g * contrastAdjusted + offset);
                         int b2 = (int)(b * contrastAdjusted + offset);
+                        int g2 = (int)(g * contrastAdjusted + offset);
+                        int r2 = (int)(r * contrastAdjusted + offset);
 
-                        r = (byte)(r2 < 0 ? 0 : r2 > 255 ? 255 : r2);
-                        g = (byte)(g2 < 0 ? 0 : g2 > 255 ? 255 : g2);
                         b = (byte)(b2 < 0 ? 0 : b2 > 255 ? 255 : b2);
+                        g = (byte)(g2 < 0 ? 0 : g2 > 255 ? 255 : g2);
+                        r = (byte)(r2 < 0 ? 0 : r2 > 255 ? 255 : r2);
 
-                        *pixel = r;
+                        *pixel = b;
                         *(pixel + 1) = g;
-                        *(pixel + 2) = b;
+                        *(pixel + 2) = r;
                     }
                 }
             });
@@ -116,9 +116,9 @@ namespace NAPS2.Scan.Images.Transforms
                     for (int x = 0; x < w; x++)
                     {
                         byte* pixel = row + x * bytesPerPixel;
-                        byte r = *pixel;
+                        byte b = *pixel;
                         byte g = *(pixel + 1);
-                        byte b = *(pixel + 2);
+                        byte r = *(pixel + 2);
 
                         int max = Math.Max(r, Math.Max(g, b));
                         int min = Math.Min(r, Math.Min(g, b));
@@ -193,9 +193,9 @@ namespace NAPS2.Scan.Images.Transforms
                             b = q;
                         }
 
-                        *pixel = r;
+                        *pixel = b;
                         *(pixel + 1) = g;
-                        *(pixel + 2) = b;
+                        *(pixel + 2) = r;
                     }
                 }
             });
@@ -335,9 +335,9 @@ namespace NAPS2.Scan.Images.Transforms
                             if (x + k < w)
                             {
                                 byte* pixel = row + (x + k) * bytesPerPixel;
-                                byte r = *pixel;
+                                byte b = *pixel;
                                 byte g = *(pixel + 1);
-                                byte b = *(pixel + 2);
+                                byte r = *(pixel + 2);
                                 // Use standard values for grayscale conversion to weight the RGB values
                                 int luma = r * 299 + g * 587 + b * 114;
                                 if (luma >= thresholdAdjusted)
@@ -408,9 +408,9 @@ namespace NAPS2.Scan.Images.Transforms
                         for (int x = 0; x < w; x++)
                         {
                             byte* pixel = row + x * bytesPerPixel;
-                            byte r = *pixel;
+                            byte b = *pixel;
                             byte g = *(pixel + 1);
-                            byte b = *(pixel + 2);
+                            byte r = *(pixel + 2);
                             // Use standard values for grayscale conversion to weight the RGB values
                             int luma = r * 299 + g * 587 + b * 114;
                             outRow[x] = luma < thresholdAdjusted;


### PR DESCRIPTION
UnsafeImageOps assumes that pixels are in RGB order but in fact they are in BGR order. I discovered this when adding a new Greyscale conversion operation. (You can see this for yourself if you load in a pure red image and set a breakpoint).

For a number of the operations this doesn't make any difference however for some this is a change that affects output...

1. Deskew - Converts to greyscale that was giving much more weight to blue than red contrary to the intent of the code/standard way of doing it.
2. Black & White - Does an intermediate greyscale conversion like Deskew using the same algorithm but again B and R were transposed so again too much weight for blue, not enough for red.
3. Hue/Saturation - Again using Red and Blue in opposite ways so now the slider options don't quite behave in the same direction.

Some images will look better, some probably worse but they will definitely be different. I have a convert to greyscale coming that I'll back-port to the convert to black and white so people can get old behavior or better yet tweak it to their requirements. 
