### PR TITLE
Add 'Invert selection' function to context menu

### DIFF
--- a/NAPS2.Core/WinForms/FDesktop.Designer.cs
+++ b/NAPS2.Core/WinForms/FDesktop.Designer.cs
@@ -97,6 +97,8 @@ namespace NAPS2.WinForms
             this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
             this.tsAltInterleave = new System.Windows.Forms.ToolStripMenuItem();
             this.tsAltDeinterleave = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsDividedScan = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.tsReverse = new System.Windows.Forms.ToolStripMenuItem();
             this.tsReverseAll = new System.Windows.Forms.ToolStripMenuItem();
@@ -107,8 +109,8 @@ namespace NAPS2.WinForms
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
             this.tsAbout = new System.Windows.Forms.ToolStripButton();
-            this.tsDividedScan = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.ctxInvertSelection = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripContainer1.ContentPanel.SuspendLayout();
             this.toolStripContainer1.TopToolStripPanel.SuspendLayout();
             this.toolStripContainer1.SuspendLayout();
@@ -185,6 +187,8 @@ namespace NAPS2.WinForms
             this.ctxView,
             this.ctxSeparator1,
             this.ctxSelectAll,
+            this.ctxInvertSelection,
+            this.toolStripMenuItem3,
             this.ctxCopy,
             this.ctxPaste,
             this.ctxSeparator2,
@@ -634,6 +638,17 @@ namespace NAPS2.WinForms
             resources.ApplyResources(this.tsAltDeinterleave, "tsAltDeinterleave");
             this.tsAltDeinterleave.Click += new System.EventHandler(this.tsAltDeinterleave_Click);
             // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
+            // 
+            // tsDividedScan
+            // 
+            this.tsDividedScan.Name = "tsDividedScan";
+            resources.ApplyResources(this.tsDividedScan, "tsDividedScan");
+            this.tsDividedScan.Click += new System.EventHandler(this.tsDividedScan_Click);
+            // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
@@ -700,16 +715,16 @@ namespace NAPS2.WinForms
             this.tsAbout.Padding = new System.Windows.Forms.Padding(10, 0, 10, 0);
             this.tsAbout.Click += new System.EventHandler(this.tsAbout_Click);
             // 
-            // tsDividedScan
+            // ctxInvertSelection
             // 
-            this.tsDividedScan.Name = "tsDividedScan";
-            resources.ApplyResources(this.tsDividedScan, "tsDividedScan");
-            this.tsDividedScan.Click += new System.EventHandler(this.tsDividedScan_Click);
+            this.ctxInvertSelection.Name = "ctxInvertSelection";
+            resources.ApplyResources(this.ctxInvertSelection, "ctxInvertSelection");
+            this.ctxInvertSelection.Click += new System.EventHandler(this.ctxInvertSelection_Click);
             // 
-            // toolStripMenuItem1
+            // toolStripMenuItem3
             // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
+            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
+            resources.ApplyResources(this.toolStripMenuItem3, "toolStripMenuItem3");
             // 
             // FDesktop
             // 
@@ -807,6 +822,8 @@ namespace NAPS2.WinForms
         private System.Windows.Forms.ToolStripMenuItem tsGrayscale;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem tsDividedScan;
+        private System.Windows.Forms.ToolStripMenuItem ctxInvertSelection;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem3;
     }
 }
 

--- a/NAPS2.Core/WinForms/FDesktop.cs
+++ b/NAPS2.Core/WinForms/FDesktop.cs
@@ -827,6 +827,12 @@ namespace NAPS2.WinForms
             SelectedIndices = Enumerable.Range(0, imageList.Images.Count);
         }
 
+        private void InvertSelection()
+        {
+            var current = new HashSet<int>(SelectedIndices);
+            SelectedIndices = Enumerable.Range(0, imageList.Images.Count).Where(i => !current.Contains(i));
+        }
+
         private void MoveDown()
         {
             if (!SelectedIndices.Any())
@@ -1668,6 +1674,11 @@ namespace NAPS2.WinForms
             SelectAll();
         }
 
+        private void ctxInvertSelection_Click(object sender, EventArgs e)
+        {
+            InvertSelection();
+        }
+
         private void ctxView_Click(object sender, EventArgs e)
         {
             PreviewImage();
@@ -2103,6 +2114,5 @@ namespace NAPS2.WinForms
         }
 
         #endregion
-
     }
 }

--- a/NAPS2.Core/WinForms/FDesktop.resx
+++ b/NAPS2.Core/WinForms/FDesktop.resx
@@ -223,28 +223,37 @@
     <value>Segoe UI, 9pt, style=Bold</value>
   </data>
   <data name="ctxView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="ctxView.Text" xml:space="preserve">
     <value>View</value>
   </data>
   <data name="ctxSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 6</value>
+    <value>177, 6</value>
   </data>
   <data name="ctxSelectAll.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
     <value>Ctrl+A</value>
   </data>
   <data name="ctxSelectAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="ctxSelectAll.Text" xml:space="preserve">
     <value>Select All</value>
+  </data>
+  <data name="ctxInvertSelection.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="ctxInvertSelection.Text" xml:space="preserve">
+    <value>Invert Selection</value>
+  </data>
+  <data name="toolStripMenuItem3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 6</value>
   </data>
   <data name="ctxCopy.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
     <value>Ctrl+C</value>
   </data>
   <data name="ctxCopy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="ctxCopy.Text" xml:space="preserve">
     <value>Copy</value>
@@ -253,22 +262,22 @@
     <value>Ctrl+V</value>
   </data>
   <data name="ctxPaste.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="ctxPaste.Text" xml:space="preserve">
     <value>Paste</value>
   </data>
   <data name="ctxSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 6</value>
+    <value>177, 6</value>
   </data>
   <data name="ctxDelete.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="ctxDelete.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 126</value>
+    <value>181, 176</value>
   </data>
   <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
     <value>contextMenuStrip</value>
@@ -292,7 +301,7 @@
     <value>thumbnailList1</value>
   </data>
   <data name="&gt;&gt;thumbnailList1.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ThumbnailList, NAPS2.Core, Version=6.1.2.20483, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ThumbnailList, NAPS2.Core, Version=6.1.2.23460, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;thumbnailList1.Parent" xml:space="preserve">
     <value>toolStripContainer1.ContentPanel</value>
@@ -897,7 +906,7 @@
     <value>3, 0</value>
   </data>
   <data name="tStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1201, 54</value>
+    <value>1184, 54</value>
   </data>
   <data name="tStrip.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1275,7 +1284,7 @@
     <value>tsMove</value>
   </data>
   <data name="&gt;&gt;tsMove.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.ToolStripDoubleButton, NAPS2.Core, Version=6.1.2.20483, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.ToolStripDoubleButton, NAPS2.Core, Version=6.1.2.23460, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tsdReorder.Name" xml:space="preserve">
     <value>tsdReorder</value>
@@ -1311,6 +1320,18 @@
     <value>tsAltDeinterleave</value>
   </data>
   <data name="&gt;&gt;tsAltDeinterleave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
+    <value>toolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsDividedScan.Name" xml:space="preserve">
+    <value>tsDividedScan</value>
+  </data>
+  <data name="&gt;&gt;tsDividedScan.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
@@ -1373,22 +1394,22 @@
   <data name="&gt;&gt;tsAbout.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tsDividedScan.Name" xml:space="preserve">
-    <value>tsDividedScan</value>
+  <data name="&gt;&gt;ctxInvertSelection.Name" xml:space="preserve">
+    <value>ctxInvertSelection</value>
   </data>
-  <data name="&gt;&gt;tsDividedScan.Type" xml:space="preserve">
+  <data name="&gt;&gt;ctxInvertSelection.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
-    <value>toolStripMenuItem1</value>
+  <data name="&gt;&gt;toolStripMenuItem3.Name" xml:space="preserve">
+    <value>toolStripMenuItem3</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+  <data name="&gt;&gt;toolStripMenuItem3.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>FDesktop</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=6.1.2.20483, Culture=neutral, PublicKeyToken=null</value>
+    <value>NAPS2.WinForms.FormBase, NAPS2.Core, Version=6.1.2.23460, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
Simply adds an "Invert selection" like you see in file manager to the context view in the main image management form.

![image](https://user-images.githubusercontent.com/118951/105608140-227e9580-5d9a-11eb-9f00-0e1486f5e270.png)
